### PR TITLE
Add `docs` nox session

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -199,6 +199,21 @@ def docs_build(session: Session) -> None:
     session.log("Building documentation.")
     session.run("sphinx-build", "-b", "html", "docs", str(docs_build_dir), "-W")
 
+@nox.session(python=DEFAULT_PYTHON_VERSION, name="docs", tags=[DOCS, BUILD])
+def docs(session: Session) -> None:
+    """Build and serve the project documentation (Sphinx)."""
+    session.log("Installing documentation dependencies...")
+    session.install("-e", ".", "--group", "docs")
+
+    session.log(f"Building documentation with py{session.python}.")
+    docs_build_dir = Path("docs") / "_build" / "html"
+
+    session.log(f"Cleaning build directory: {docs_build_dir}")
+    session.run("sphinx-build", "-b", "html", "docs", str(docs_build_dir), "-E")
+
+    session.log("Building and serving documentation.")
+    session.run("sphinx-autobuild", "--open-browser", "docs", str(docs_build_dir))
+
 
 @nox.session(python=False, name="build-python", tags=[BUILD])
 def build_python(session: Session) -> None:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -40,6 +40,7 @@ docs = [
     "furo>=2024.8.6",
     "myst-parser>=3.0.1",
     "sphinx>=7.4.7",
+    "sphinx-autobuild>=2024.10.3",
     "sphinx-autodoc-typehints>=2.3.0",
     "sphinx-copybutton>=0.5.2",
     "sphinx-tabs>=3.4.7",


### PR DESCRIPTION
Many thanks for this fork, I've adopted it in [my package](https://github.com/dbatten5/maison).
I noticed the `noxfile` was missing a `docs` session that builds and serves the docs locally
so I've added it here, based on what was in the hypermodern python package `noxfile`.